### PR TITLE
Update the method for checking if there are uncommitted changes.

### DIFF
--- a/src/oc_extras/utils/utils.py
+++ b/src/oc_extras/utils/utils.py
@@ -27,9 +27,9 @@ def has_uncommitted_changes() -> bool:
     Returns:
         bool: wether there are uncommiteed changes.
     """
-    command = "git status"
+    command = "git status --porcelain"
     output = subprocess.check_output(command.split()).strip().decode("utf-8")
-    return "nothing to commit (working directory clean)" not in output
+    return len(output) > 0
 
 
 def get_current_time() -> str:


### PR DESCRIPTION
@odelalleau mentioned that the current implementation fails for them. For them, `git status` returns `nothing to commit, working tree clean` when everything is clean while we expect `nothing to commit (working directory clean)` note the extra brackets. The new command returns consistent output.